### PR TITLE
Fix invalid PLAY request leading to 405 errors

### DIFF
--- a/library-client-rtsp/src/main/java/com/alexvas/rtsp/RtspClient.java
+++ b/library-client-rtsp/src/main/java/com/alexvas/rtsp/RtspClient.java
@@ -760,7 +760,7 @@ public class RtspClient {
     throws IOException {
         if (DEBUG)
             Log.v(TAG, "sendPlayCommand(request=\"" + request + "\", cSeq=" + cSeq + ")");
-        outputStream.write(("PLAY " + request + "/ RTSP/1.0" + CRLF).getBytes());
+        outputStream.write(("PLAY " + request + " RTSP/1.0" + CRLF).getBytes());
         outputStream.write(("Range: npt=0.000-" + CRLF).getBytes());
         if (authToken != null)
             outputStream.write(("Authorization: " + authToken + CRLF).getBytes());


### PR DESCRIPTION
The last slash leads to 405 errors at my cameras. So no stream can be played. Removing it solves the problem.