### PR TITLE
Refactor FrameQueue push method for handling full queueSize scenario.

### DIFF
--- a/library-client-rtsp/src/main/java/com/alexvas/rtsp/codec/FrameQueue.kt
+++ b/library-client-rtsp/src/main/java/com/alexvas/rtsp/codec/FrameQueue.kt
@@ -22,7 +22,7 @@ class FrameQueue(private val frameQueueSize: Int) {
             return true
         }
         if (queue.size >= frameQueueSize) {
-            Log.w(TAG, "Cannot add frame, queue is full. Queue Size :${queue.size}")
+            Log.w(TAG, "Cannot add frame, queue is full. Queue size: ${queue.size}")
             Thread.currentThread().interrupt()
             queue.poll()
             queue.clear()
@@ -34,16 +34,16 @@ class FrameQueue(private val frameQueueSize: Int) {
     @Throws(InterruptedException::class)
     fun pop(): Frame? {
         try {
-            if (queue.size>0) {
+            if (queue.size > 0) {
                 val frame: Frame? = queue.poll(1000, TimeUnit.MILLISECONDS)
 
                 if (frame == null) {
-                    Log.w(TAG, "Cannot get frame, queue is empty. Queue Size :${queue.size}")
+                    Log.w(TAG, "Cannot get frame, queue is empty. Queue size: ${queue.size}")
                 }
                 return frame
             }
         } catch (e: InterruptedException) {
-            Log.i(TAG, "pop: InterruptedException caught. Queue Size: ${queue.size} ", e)
+            Log.w(TAG, "InterruptedException caught. Queue size: ${queue.size}")
             queue.clear()
             Thread.currentThread().interrupt()
         }

--- a/library-client-rtsp/src/main/java/com/alexvas/rtsp/codec/FrameQueue.kt
+++ b/library-client-rtsp/src/main/java/com/alexvas/rtsp/codec/FrameQueue.kt
@@ -34,12 +34,17 @@ class FrameQueue(private val frameQueueSize: Int) {
     @Throws(InterruptedException::class)
     fun pop(): Frame? {
         try {
-            val frame: Frame? = queue.poll(1000, TimeUnit.MILLISECONDS)
-            if (frame == null) {
-                Log.w(TAG, "Cannot get frame, queue is empty")
+            if (queue.size>0) {
+                val frame: Frame? = queue.poll(1000, TimeUnit.MILLISECONDS)
+
+                if (frame == null) {
+                    Log.w(TAG, "Cannot get frame, queue is empty. Queue Size :${queue.size}")
+                }
+                return frame
             }
-            return frame
         } catch (e: InterruptedException) {
+            Log.i(TAG, "pop: InterruptedException caught. Queue Size: ${queue.size} ", e)
+            queue.clear()
             Thread.currentThread().interrupt()
         }
         return null

--- a/library-client-rtsp/src/main/java/com/alexvas/rtsp/codec/FrameQueue.kt
+++ b/library-client-rtsp/src/main/java/com/alexvas/rtsp/codec/FrameQueue.kt
@@ -5,7 +5,7 @@ import java.util.concurrent.ArrayBlockingQueue
 import java.util.concurrent.BlockingQueue
 import java.util.concurrent.TimeUnit
 
-class FrameQueue(frameQueueSize: Int) {
+class FrameQueue(private val frameQueueSize: Int) {
 
     data class Frame (
         val data: ByteArray,
@@ -20,6 +20,12 @@ class FrameQueue(frameQueueSize: Int) {
     fun push(frame: Frame): Boolean {
         if (queue.offer(frame, 5, TimeUnit.MILLISECONDS)) {
             return true
+        }
+        if (queue.size >= frameQueueSize) {
+            Log.w(TAG, "Cannot add frame, queue is full. Queue Size :${queue.size}")
+            Thread.currentThread().interrupt()
+            queue.poll()
+            queue.clear()
         }
         Log.w(TAG, "Cannot add frame, queue is full")
         return false


### PR DESCRIPTION
- Introduces a check for the queue size to determine if it exceeds a predefined limit (`frameQueueSize`).
- If the queue is full, logs a warning message including the current queue size.
- Interrupts the current thread to signal that the operation was unsuccessful.
- Removes the oldest item from the queue using `queue.poll()` to make room for the new frame.
- Clears the entire queue to ensure consistency in case of a full queue.