### PR TITLE
Fixed video playback failure

### DIFF
--- a/library-client-rtsp/src/main/java/com/alexvas/rtsp/codec/VideoDecodeThread.kt
+++ b/library-client-rtsp/src/main/java/com/alexvas/rtsp/codec/VideoDecodeThread.kt
@@ -227,7 +227,6 @@ abstract class VideoDecodeThread (
         val format = getDecoderMediaFormat(decoder)
         decoderCreated(decoder, format)
         decoder.start()
-        videoFrameQueue.clear()
 
         val capabilities = decoder.codecInfo.getCapabilitiesForType(mimeType)
         val lowLatencySupport = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {


### PR DESCRIPTION
After decoding begins, clearing the video queue may cause playback failure.