### PR TITLE
Support video stabilization

### DIFF
--- a/app/src/main/java/com/alexvas/rtsp/demo/live/LiveFragment.kt
+++ b/app/src/main/java/com/alexvas/rtsp/demo/live/LiveFragment.kt
@@ -2,14 +2,18 @@ package com.alexvas.rtsp.demo.live
 
 import android.annotation.SuppressLint
 import android.graphics.Bitmap
-import android.net.Uri
 import android.os.Bundle
 import android.os.Handler
 import android.os.HandlerThread
 import android.util.Log
-import android.view.*
+import android.view.LayoutInflater
+import android.view.PixelCopy
+import android.view.View
+import android.view.ViewGroup
+import android.view.WindowManager
 import android.widget.Toast
 import androidx.constraintlayout.widget.ConstraintSet
+import androidx.core.net.toUri
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
 import com.alexvas.rtsp.codec.VideoDecodeThread
@@ -22,7 +26,6 @@ import java.util.Timer
 import java.util.TimerTask
 import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.math.min
-import androidx.core.net.toUri
 
 @SuppressLint("LogNotTimber")
 class LiveFragment : Fragment() {
@@ -276,6 +279,10 @@ class LiveFragment : Fragment() {
                 binding.llRtspParams.etRtspPassword.setText(it)
         }
 
+        binding.cbVideoStabilization.setOnCheckedChangeListener { _, isChecked ->
+            binding.svVideoSurface.videoStabilizationEnabled = isChecked
+        }
+
         binding.cbExperimentalRewriteSps.setOnCheckedChangeListener { _, isChecked ->
             binding.svVideoSurface.experimentalUpdateSpsFrameWithLowLatencyParams = isChecked
         }
@@ -326,6 +333,7 @@ class LiveFragment : Fragment() {
                         userAgent = "rtsp-client-android"
                     )
                     debug = binding.llRtspParams.cbDebug.isChecked
+                    videoStabilizationEnabled = binding.cbVideoStabilization.isChecked
                     start(
                         requestVideo = binding.llRtspParams.cbVideo.isChecked,
                         requestAudio = binding.llRtspParams.cbAudio.isChecked,

--- a/app/src/main/res/layout/fragment_live.xml
+++ b/app/src/main/res/layout/fragment_live.xml
@@ -18,6 +18,14 @@
             layout="@layout/layout_rtsp_params"/>
 
         <CheckBox
+            android:id="@+id/cbVideoStabilization"
+            android:text="Video Stabilization"
+            android:checked="false"
+            android:layout_margin="5dp"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content" />
+
+        <CheckBox
             android:id="@+id/cbExperimentalRewriteSps"
             android:text="Rewrite SPS frames w/ low-latency params (EXPERIMENTAL)"
             android:checked="false"

--- a/library-client-rtsp/src/main/java/com/alexvas/rtsp/codec/VideoDecoderBitmapThread.kt
+++ b/library-client-rtsp/src/main/java/com/alexvas/rtsp/codec/VideoDecoderBitmapThread.kt
@@ -27,7 +27,12 @@ class VideoDecoderBitmapThread (
         mediaCodec.configure(mediaFormat, null, null, 0)
     }
 
-    override fun releaseOutputBuffer(mediaCodec: MediaCodec, outIndex: Int, render: Boolean) {
+    override fun releaseOutputBuffer(
+        mediaCodec: MediaCodec,
+        outIndex: Int,
+        bufferInfo: MediaCodec.BufferInfo,
+        render: Boolean
+    ) {
         val image = mediaCodec.getOutputImage(outIndex)
         image?.let {
             if (colorConverter == null)

--- a/library-client-rtsp/src/main/java/com/alexvas/rtsp/codec/VideoDecoderSurfaceThread.kt
+++ b/library-client-rtsp/src/main/java/com/alexvas/rtsp/codec/VideoDecoderSurfaceThread.kt
@@ -4,8 +4,10 @@ import android.media.MediaCodec
 import android.media.MediaFormat
 import android.util.Log
 import android.view.Surface
+import java.util.concurrent.TimeUnit
+import kotlin.math.max
 
-class VideoDecoderSurfaceThread (
+class VideoDecoderSurfaceThread(
     private val surface: Surface,
     mimeType: String,
     width: Int,
@@ -13,22 +15,126 @@ class VideoDecoderSurfaceThread (
     rotation: Int, // 0, 90, 180, 270
     videoFrameQueue: VideoFrameQueue,
     videoDecoderListener: VideoDecoderListener,
-    videoDecoderType: DecoderType = DecoderType.HARDWARE
-): VideoDecodeThread(
-    mimeType, width, height, rotation, videoFrameQueue, videoDecoderListener, videoDecoderType) {
+    videoDecoderType: DecoderType = DecoderType.HARDWARE,
+    enableVideoStabilization: Boolean = true,
+) : VideoDecodeThread(
+    mimeType, width, height, rotation, videoFrameQueue, videoDecoderListener, videoDecoderType
+){
+
+    init {
+        setVideoStabilizationEnabled(enableVideoStabilization)
+    }
 
     override fun decoderCreated(mediaCodec: MediaCodec, mediaFormat: MediaFormat) {
         if (!surface.isValid) {
             Log.e(TAG, "Surface invalid")
         }
         mediaCodec.configure(mediaFormat, surface, null, 0)
+        resetFrameTiming()
     }
 
-    override fun releaseOutputBuffer(mediaCodec: MediaCodec, outIndex: Int, render: Boolean) {
-        mediaCodec.releaseOutputBuffer(outIndex, render && surface.isValid)
+    override fun releaseOutputBuffer(
+        mediaCodec: MediaCodec,
+        outIndex: Int,
+        bufferInfo: MediaCodec.BufferInfo,
+        render: Boolean
+    ) {
+        if (!render || !surface.isValid) {
+            mediaCodec.releaseOutputBuffer(outIndex, false)
+            return
+        }
+
+        if (!isVideoStabilizationEnabled()) {
+            mediaCodec.releaseOutputBuffer(outIndex, true)
+            return
+        }
+
+        val ptsUs = bufferInfo.presentationTimeUs
+        val nowNs = System.nanoTime()
+
+        if (streamStartPtsUs == null || playbackStartRealtimeNs == null) {
+            // First frame (or after a reset): initialize all timing anchors.
+            streamStartPtsUs = ptsUs
+            playbackStartRealtimeNs = nowNs
+            lastFrameReleaseTimeNs = nowNs
+            lastPresentationTimeUs = ptsUs
+            mediaCodec.releaseOutputBuffer(outIndex, nowNs)
+            return
+        }
+
+        var targetNs = playbackStartRealtimeNs!! + (ptsUs - streamStartPtsUs!!) * 1000L
+        var adjustedNowNs = System.nanoTime()
+
+        if (lastPresentationTimeUs != Long.MIN_VALUE && ptsUs < lastPresentationTimeUs) {
+            // PTS went backwards (e.g. codec reordering). Re-base the clock to avoid negative deltas.
+            streamStartPtsUs = ptsUs
+            playbackStartRealtimeNs = adjustedNowNs
+            targetNs = adjustedNowNs
+        }
+
+        if (lastFrameReleaseTimeNs != Long.MIN_VALUE) {
+            // Ensure we never schedule two frames closer together than the min spacing.
+            targetNs = max(targetNs, lastFrameReleaseTimeNs + MIN_FRAME_SPACING_NS)
+        }
+
+        adjustedNowNs = System.nanoTime()
+        val latenessNs = adjustedNowNs - targetNs
+
+        if (latenessNs >= FRAME_DROP_THRESHOLD_NS) {
+            // Frame is critically late; drop to keep playback responsive.
+            mediaCodec.releaseOutputBuffer(outIndex, false)
+            lastFrameReleaseTimeNs = adjustedNowNs
+            return
+        }
+
+        var correctedTargetNs = targetNs
+        if (latenessNs > 0) {
+            // For mild lateness, shift the playback baseline forward so future frames stay aligned.
+            val correction = minOf(latenessNs, FRAME_DROP_THRESHOLD_NS)
+            playbackStartRealtimeNs = playbackStartRealtimeNs?.plus(correction)
+            correctedTargetNs += correction
+        }
+
+        if (correctedTargetNs <= adjustedNowNs + RENDER_EARLY_MARGIN_NS) {
+            // Already at/behind the target time: render immediately using the current VSYNC.
+            mediaCodec.releaseOutputBuffer(outIndex, true)
+            lastFrameReleaseTimeNs = adjustedNowNs
+        } else {
+            // Still early enough: hand the desired release timestamp to MediaCodec for VSYNC alignment.
+            mediaCodec.releaseOutputBuffer(outIndex, correctedTargetNs)
+            lastFrameReleaseTimeNs = correctedTargetNs
+        }
+
+        lastPresentationTimeUs = ptsUs
     }
 
     override fun decoderDestroyed(mediaCodec: MediaCodec) {
+        resetFrameTiming()
+    }
+
+    private fun resetFrameTiming() {
+        streamStartPtsUs = null
+        playbackStartRealtimeNs = null
+        lastFrameReleaseTimeNs = Long.MIN_VALUE
+        lastPresentationTimeUs = Long.MIN_VALUE
+    }
+
+    // Presentation time (in RTP units converted to microseconds) of the first frame used as the PTS baseline.
+    private var streamStartPtsUs: Long? = null
+
+    // Monotonic clock timestamp corresponding to streamStartPtsUs, used to map future frames to real time.
+    private var playbackStartRealtimeNs: Long? = null
+
+    // Timestamp of the most recently released frame to enforce minimum spacing between consecutive frames.
+    private var lastFrameReleaseTimeNs: Long = Long.MIN_VALUE
+
+    // Last presentation timestamp we processed; used to detect wrap-around or backwards jumps.
+    private var lastPresentationTimeUs: Long = Long.MIN_VALUE
+
+    companion object {
+        private val FRAME_DROP_THRESHOLD_NS = TimeUnit.MILLISECONDS.toNanos(80)
+        private val MIN_FRAME_SPACING_NS = TimeUnit.MILLISECONDS.toNanos(1)
+        private val RENDER_EARLY_MARGIN_NS = TimeUnit.MILLISECONDS.toNanos(2)
     }
 
 }

--- a/library-client-rtsp/src/main/java/com/alexvas/rtsp/widget/RtspImageView.kt
+++ b/library-client-rtsp/src/main/java/com/alexvas/rtsp/widget/RtspImageView.kt
@@ -24,7 +24,7 @@ class RtspImageView : ImageView {
     }
 
     private var rtspProcessor = RtspProcessor(onVideoDecoderCreateRequested = {
-            videoMimeType, videoRotation, videoFrameQueue, videoDecoderListener, videoDecoderType ->
+            videoMimeType, videoRotation, videoFrameQueue, videoDecoderListener, videoDecoderType, _ ->
         VideoDecoderBitmapThread(
             videoMimeType,
             videoRotation,

--- a/library-client-rtsp/src/main/java/com/alexvas/rtsp/widget/RtspProcessor.kt
+++ b/library-client-rtsp/src/main/java/com/alexvas/rtsp/widget/RtspProcessor.kt
@@ -33,7 +33,8 @@ class RtspProcessor(
         videoRotation: Int, // 0, 90, 180, 270
         videoFrameQueue: VideoFrameQueue,
         videoDecoderListener: VideoDecoderListener,
-        videoDecoderType: DecoderType
+        videoDecoderType: DecoderType,
+        videoStabilizationEnabled: Boolean,
     ) -> VideoDecodeThread)
 ) {
 
@@ -107,6 +108,15 @@ class RtspProcessor(
      * decoder latency by 2x times on some hardware decoders.
      */
     var experimentalUpdateSpsFrameWithLowLatencyParams = false
+
+    /**
+     * Enables the playback smoothing logic inside the video decoder.
+     */
+    var videoStabilizationEnabled: Boolean = false
+        set(value) {
+            field = value
+            videoDecodeThread?.setVideoStabilizationEnabled(value)
+        }
 
     /**
      * Status listener for getting RTSP event updates.
@@ -411,6 +421,7 @@ class RtspProcessor(
                 videoFrameQueue,
                 videoDecoderListener,
                 videoDecoderType,
+                videoStabilizationEnabled,
             )
             videoDecodeThread!!.apply {
                 name = "RTSP video thread [${getUriName()}]"

--- a/library-client-rtsp/src/main/java/com/alexvas/rtsp/widget/RtspSurfaceView.kt
+++ b/library-client-rtsp/src/main/java/com/alexvas/rtsp/widget/RtspSurfaceView.kt
@@ -24,7 +24,13 @@ open class RtspSurfaceView: SurfaceView {
 
     private var rtspProcessor = RtspProcessor(
         onVideoDecoderCreateRequested = {
-            videoMimeType, videoRotation, videoFrameQueue, videoDecoderListener, videoDecoderType ->
+                videoMimeType,
+                videoRotation,
+                videoFrameQueue,
+                videoDecoderListener,
+                videoDecoderType,
+                videoStabilizationEnabled,
+            ->
             VideoDecoderSurfaceThread(
                 holder.surface,
                 videoMimeType,
@@ -34,6 +40,7 @@ open class RtspSurfaceView: SurfaceView {
                 videoFrameQueue,
                 videoDecoderListener,
                 videoDecoderType,
+                enableVideoStabilization = videoStabilizationEnabled,
             )
         }
     )
@@ -57,6 +64,11 @@ open class RtspSurfaceView: SurfaceView {
     var debug: Boolean
         get() = rtspProcessor.debug
         set(value) { rtspProcessor.debug = value }
+
+    /** Enables decoder-side playback smoothing. Disabled by default. */
+    var videoStabilizationEnabled: Boolean
+        get() = rtspProcessor.videoStabilizationEnabled
+        set(value) { rtspProcessor.videoStabilizationEnabled = value }
 
     private val surfaceCallback = object: SurfaceHolder.Callback {
         override fun surfaceCreated(holder: SurfaceHolder) {


### PR DESCRIPTION
Important PR
This PR primarily addresses the issue of video stuttering caused by uneven frame rates after video decoding.
The feature is implemented as a toggle switch that can be turned on or off.

This screen recording demonstrates a comparison of RTSP video stream playback before and after enabling stabilization.


https://github.com/user-attachments/assets/b982b0da-771b-4adf-a7e5-b3ffa3b15032


https://github.com/alexeyvasilyev/rtsp-client-android/pull/128#issuecomment-3475944851
