### PR TITLE
Recalculate Digest authentication for DESCRIBE

### DIFF
--- a/library-client-rtsp/src/main/java/com/alexvas/rtsp/RtspClient.java
+++ b/library-client-rtsp/src/main/java/com/alexvas/rtsp/RtspClient.java
@@ -355,6 +355,9 @@ public class RtspClient {
 // a=control:trackID=2
             checkExitFlag(exitFlag);
 
+            if (digestRealmNonce != null) {
+                authToken = getDigestAuthHeader(username, password, "DESCRIBE", uriRtsp, digestRealmNonce.first, digestRealmNonce.second);
+            }
             sendDescribeCommand(outputStream, uriRtsp, cSeq.addAndGet(1), userAgent, authToken);
             status = readResponseStatusCode(inputStream);
             headers = readResponseHeaders(inputStream);


### PR DESCRIPTION
The library handles the first 401 Digest challenge from OPTIONS correctly, but the following DESCRIBE request does NOT recalculate the digest, causing DESCRIBE to be sent with an invalid Authorization header. In some cases, this triggers the security mechanism and results in the IP being blocked, just like with the camera I’m using.
