### PR TITLE
support split nals

### DIFF
--- a/library-client-rtsp/src/main/java/com/alexvas/rtsp/RtspClient.java
+++ b/library-client-rtsp/src/main/java/com/alexvas/rtsp/RtspClient.java
@@ -628,6 +628,8 @@ public class RtspClient {
         }
     }
 
+    private static long lastTimestamp = 0;
+
     private static void readRtpData(
             @NonNull InputStream inputStream,
             @NonNull SdpInfo sdpInfo,
@@ -682,16 +684,19 @@ public class RtspClient {
                 if (videoSeqNum > header.sequenceNumber)
                     Log.w(TAG, "Invalid video seq num " + videoSeqNum + "/" + header.sequenceNumber);
                 videoSeqNum = header.sequenceNumber;
+                long ts = header.timeStamp;
+                if (lastTimestamp == 0) lastTimestamp = ts;
 
                 byte[] nalUnit;
                 // If extendion bit set in header, skip extension data
                 if (header.extension == 1) {
                     int skipBytes = ((data[2] & 0xFF) << 8 | (data[3] & 0xFF)) * 4 + 4;
                     nalUnit = videoParser.processRtpPacketAndGetNalUnit(Arrays.copyOfRange(data, skipBytes, data.length),
-                            header.payloadSize - skipBytes, header.marker == 1);
+                            header.payloadSize - skipBytes, header.marker == 1 || ts != lastTimestamp);
                 } else {
-                    nalUnit = videoParser.processRtpPacketAndGetNalUnit(data, header.payloadSize, header.marker == 1);
+                    nalUnit = videoParser.processRtpPacketAndGetNalUnit(data, header.payloadSize, header.marker == 1 ||  ts != lastTimestamp);
                 }
+                lastTimestamp = ts;
 
                 if (nalUnit != null) {
                     boolean isH265 = sdpInfo.videoTrack.videoCodec == VIDEO_CODEC_H265;

--- a/library-client-rtsp/src/main/java/com/alexvas/rtsp/RtspClient.java
+++ b/library-client-rtsp/src/main/java/com/alexvas/rtsp/RtspClient.java
@@ -32,7 +32,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicLong;
 
 //OPTIONS rtsp://10.0.1.145:88/videoSub RTSP/1.0
 //CSeq: 1

--- a/library-client-rtsp/src/main/java/com/alexvas/rtsp/RtspClient.java
+++ b/library-client-rtsp/src/main/java/com/alexvas/rtsp/RtspClient.java
@@ -32,6 +32,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 
 //OPTIONS rtsp://10.0.1.145:88/videoSub RTSP/1.0
 //CSeq: 1
@@ -628,8 +629,6 @@ public class RtspClient {
         }
     }
 
-    private static long lastTimestamp = 0;
-
     private static void readRtpData(
             @NonNull InputStream inputStream,
             @NonNull SdpInfo sdpInfo,
@@ -684,19 +683,16 @@ public class RtspClient {
                 if (videoSeqNum > header.sequenceNumber)
                     Log.w(TAG, "Invalid video seq num " + videoSeqNum + "/" + header.sequenceNumber);
                 videoSeqNum = header.sequenceNumber;
-                long ts = header.timeStamp;
-                if (lastTimestamp == 0) lastTimestamp = ts;
 
                 byte[] nalUnit;
                 // If extendion bit set in header, skip extension data
                 if (header.extension == 1) {
                     int skipBytes = ((data[2] & 0xFF) << 8 | (data[3] & 0xFF)) * 4 + 4;
                     nalUnit = videoParser.processRtpPacketAndGetNalUnit(Arrays.copyOfRange(data, skipBytes, data.length),
-                            header.payloadSize - skipBytes, header.marker == 1 || ts != lastTimestamp);
+                            header.payloadSize - skipBytes, header.marker == 1);
                 } else {
-                    nalUnit = videoParser.processRtpPacketAndGetNalUnit(data, header.payloadSize, header.marker == 1 ||  ts != lastTimestamp);
+                    nalUnit = videoParser.processRtpPacketAndGetNalUnit(data, header.payloadSize, header.marker == 1);
                 }
-                lastTimestamp = ts;
 
                 if (nalUnit != null) {
                     boolean isH265 = sdpInfo.videoTrack.videoCodec == VIDEO_CODEC_H265;

--- a/library-client-rtsp/src/main/java/com/alexvas/rtsp/parser/RtpH264Parser.kt
+++ b/library-client-rtsp/src/main/java/com/alexvas/rtsp/parser/RtpH264Parser.kt
@@ -3,8 +3,11 @@ package com.alexvas.rtsp.parser
 import android.util.Log
 import com.alexvas.utils.VideoCodecUtils
 import com.alexvas.utils.VideoCodecUtils.getH264NalUnitTypeString
+import java.io.ByteArrayOutputStream
 
 class RtpH264Parser: RtpParser() {
+
+    private var stream = ByteArrayOutputStream()
 
     override fun processRtpPacketAndGetNalUnit(data: ByteArray, length: Int, marker: Boolean): ByteArray? {
         if (DEBUG) Log.v(TAG, "processRtpPacketAndGetNalUnit(data.size=${data.size}, length=$length, marker=$marker)")
@@ -57,7 +60,13 @@ class RtpH264Parser: RtpParser() {
                 if (DEBUG) Log.d(TAG, "Single NAL (${nalUnit.size})")
             }
         }
-        return nalUnit
+        nalUnit?.let { stream.write(it) }
+        if (marker) {
+            val result = stream.toByteArray()
+            stream = ByteArrayOutputStream()
+            return result
+        }
+        return null
     }
 
     private fun addStartFragmentedPacket(data: ByteArray, length: Int) {

--- a/library-client-rtsp/src/main/java/com/alexvas/rtsp/parser/RtpH265Parser.kt
+++ b/library-client-rtsp/src/main/java/com/alexvas/rtsp/parser/RtpH265Parser.kt
@@ -1,8 +1,11 @@
 package com.alexvas.rtsp.parser
 
 import android.util.Log
+import java.io.ByteArrayOutputStream
 
 class RtpH265Parser: RtpParser() {
+
+    private var stream = ByteArrayOutputStream()
 
     override fun processRtpPacketAndGetNalUnit(data: ByteArray, length: Int, marker: Boolean): ByteArray? {
         if (DEBUG) Log.v(TAG, "processRtpPacketAndGetNalUnit(length=$length, marker=$marker)")
@@ -25,8 +28,13 @@ class RtpH265Parser: RtpParser() {
         } else {
             Log.e(TAG, "RTP H265 payload type [${nalType}] not supported.")
         }
-
-        return nalUnit
+        nalUnit?.let { stream.write(it) }
+        if (marker) {
+            val result = stream.toByteArray()
+            stream = ByteArrayOutputStream()
+            return result
+        }
+        return null
     }
 
     private fun processFragmentationUnitPacket(data: ByteArray, length: Int, marker: Boolean): ByteArray? {


### PR DESCRIPTION
Hello,

H264 and H265 parser never should assume that the frame can't come in multiple nals splitted in RTP packets.
For example, this is a valid video frame of a keyframe:
```
vps nal -> small single RTP (no marked)
sps nal -> small single RTP (no marked)
pps nal -> small single RTP (no marked)
IDR nal slice1 -> big multi RTP (last packet no marked)
IDR nal slice2 -> big multi RTP (last packet marked, the frame finished)
```
Previously the library was doing:
```
vps nal -> small single RTP (no marked) -> assume this is a frame
sps nal -> small single RTP (no marked) -> assume this is a frame
pps nal -> small single RTP (no marked) -> assume this is a frame
IDR nal slice1 -> big multi RTP (last packet no marked) -> assume this is a frame
IDR nal slice2 -> big multi RTP (last packet marked, the frame finished) -> assume this is a frame
```

Video frames must be completed waiting for marked RTP packet