### PR TITLE
Add audio playback volume control. Issue #138

### DIFF
--- a/app/src/main/java/com/alexvas/rtsp/demo/live/LiveFragment.kt
+++ b/app/src/main/java/com/alexvas/rtsp/demo/live/LiveFragment.kt
@@ -11,6 +11,7 @@ import android.view.PixelCopy
 import android.view.View
 import android.view.ViewGroup
 import android.view.WindowManager
+import android.widget.SeekBar
 import android.widget.Toast
 import androidx.constraintlayout.widget.ConstraintSet
 import androidx.core.net.toUri
@@ -286,6 +287,16 @@ class LiveFragment : Fragment() {
         binding.cbExperimentalRewriteSps.setOnCheckedChangeListener { _, isChecked ->
             binding.svVideoSurface.experimentalUpdateSpsFrameWithLowLatencyParams = isChecked
         }
+
+        binding.sbVolume.setOnSeekBarChangeListener(object : SeekBar.OnSeekBarChangeListener {
+            override fun onProgressChanged(seekBar: SeekBar, progress: Int, fromUser: Boolean) {
+                val volume = progress / 100f
+                binding.svVideoSurface.volume = volume
+                binding.ivVideoImage.volume = volume
+            }
+            override fun onStartTrackingTouch(seekBar: SeekBar) {}
+            override fun onStopTrackingTouch(seekBar: SeekBar) {}
+        })
 
         binding.bnRotate0.setOnClickListener {
             binding.svVideoSurface.videoRotation = 0

--- a/app/src/main/res/layout/fragment_live.xml
+++ b/app/src/main/res/layout/fragment_live.xml
@@ -33,6 +33,29 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content" />
 
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="center_vertical"
+            android:layout_marginStart="5dp"
+            android:layout_marginTop="10dp">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Volume:" />
+
+            <SeekBar
+                android:id="@+id/sbVolume"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:max="100"
+                android:progress="100" />
+
+        </LinearLayout>
+
         <Button
             android:layout_marginTop="40dp"
             android:id="@+id/bnStartStopSurface"

--- a/library-client-rtsp/src/main/java/com/alexvas/rtsp/codec/AudioDecodeThread.kt
+++ b/library-client-rtsp/src/main/java/com/alexvas/rtsp/codec/AudioDecodeThread.kt
@@ -15,6 +15,20 @@ class AudioDecodeThread (
 
     private var isRunning = true
 
+    @Volatile
+    private var audioTrack: AudioTrack? = null
+
+    /**
+     * Playback volume gain in range 0.0 (silence) .. 1.0 (max, unmodified signal).
+     * Can be changed at any time, before or after the thread is started.
+     */
+    @Volatile
+    var volume: Float = 1.0f
+        set(value) {
+            field = value.coerceIn(0.0f, 1.0f)
+            audioTrack?.setVolume(field)
+        }
+
     fun stopAsync() {
         if (DEBUG) Log.v(TAG, "stopAsync()")
         isRunning = false
@@ -113,6 +127,9 @@ class AudioDecodeThread (
                 bufferSize,
                 AudioTrack.MODE_STREAM,
                 0)
+        this.audioTrack = audioTrack
+        // Apply volume requested before the track was created
+        audioTrack.setVolume(volume)
         audioTrack.play()
 
         val bufferInfo = MediaCodec.BufferInfo()
@@ -182,6 +199,7 @@ class AudioDecodeThread (
         }
         audioTrack.flush()
         audioTrack.release()
+        this.audioTrack = null
 
         try {
             decoder.stop()

--- a/library-client-rtsp/src/main/java/com/alexvas/rtsp/widget/RtspImageView.kt
+++ b/library-client-rtsp/src/main/java/com/alexvas/rtsp/widget/RtspImageView.kt
@@ -59,6 +59,11 @@ class RtspImageView : ImageView {
         get() = rtspProcessor.debug
         set(value) { rtspProcessor.debug = value }
 
+    /** Audio playback volume gain in range 0.0 (silence) .. 1.0 (max). */
+    var volume: Float
+        get() = rtspProcessor.volume
+        set(value) { rtspProcessor.volume = value }
+
     constructor(context: Context) : super(context) {
         initView(context, null, 0)
     }

--- a/library-client-rtsp/src/main/java/com/alexvas/rtsp/widget/RtspProcessor.kt
+++ b/library-client-rtsp/src/main/java/com/alexvas/rtsp/widget/RtspProcessor.kt
@@ -119,6 +119,16 @@ class RtspProcessor(
         }
 
     /**
+     * Audio playback volume gain in range 0.0 (silence) .. 1.0 (max).
+     * Applies to the currently playing stream and to any subsequent one.
+     */
+    var volume: Float = 1.0f
+        set(value) {
+            field = value.coerceIn(0.0f, 1.0f)
+            audioDecodeThread?.volume = field
+        }
+
+    /**
      * Status listener for getting RTSP event updates.
      */
     var statusListener: RtspStatusListener? = null
@@ -434,6 +444,7 @@ class RtspProcessor(
                 audioMimeType, audioSampleRate, audioChannelCount, audioCodecConfig, audioFrameQueue)
             audioDecodeThread!!.apply {
                 name = "RTSP audio thread [${getUriName()}]"
+                volume = this@RtspProcessor.volume
                 start()
             }
         }

--- a/library-client-rtsp/src/main/java/com/alexvas/rtsp/widget/RtspSurfaceView.kt
+++ b/library-client-rtsp/src/main/java/com/alexvas/rtsp/widget/RtspSurfaceView.kt
@@ -65,6 +65,11 @@ open class RtspSurfaceView: SurfaceView {
         get() = rtspProcessor.debug
         set(value) { rtspProcessor.debug = value }
 
+    /** Audio playback volume gain in range 0.0 (silence) .. 1.0 (max). */
+    var volume: Float
+        get() = rtspProcessor.volume
+        set(value) { rtspProcessor.volume = value }
+
     /** Enables decoder-side playback smoothing. Disabled by default. */
     var videoFrameRateStabilization: Boolean
         get() = rtspProcessor.videoFrameRateStabilization


### PR DESCRIPTION
Expose a `volume` property (0.0..1.0) through the RtspSurfaceView / RtspImageView widgets down to the AudioDecodeThread, which applies it to the AudioTrack. The value is applied live and also carried over to newly created audio threads on reconnect.

The demo app gets a volume SeekBar wired to both widgets.